### PR TITLE
Fixing errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # shortcuts-stats Changelog
 
 ## [Unreleased]
+- fixing errors like: java.lang.Throwable: ID 'resetShortcutsAction' is already taken by action
 
 ## [3.0.0] - 2025-03-29
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,7 @@ pluginGroup = com.github.marbor112.shortcutsstats
 pluginName = shortcuts-stats
 pluginRepositoryUrl = https://github.com/borowskimarcin/shortcuts-stats
 # SemVer format -> https://semver.org
-pluginVersion = 3.0.0
-
+pluginVersion = 3.0.1
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
 pluginUntilBuild =300.*

--- a/src/main/java/com/github/marbor/shortcutsstats/StatsToolWindow.java
+++ b/src/main/java/com/github/marbor/shortcutsstats/StatsToolWindow.java
@@ -100,8 +100,6 @@ public class StatsToolWindow implements Observer {
         ActionToolbar toolbar = ActionManager.getInstance().createActionToolbar("shortcuts-toolbar", actions, true);
         toolbar.setTargetComponent(toolBarPanel);
         toolBarPanel.add(toolbar.getComponent());
-        ActionManager.getInstance().registerAction("resetShortcutsAction", resetAction);
-        ActionManager.getInstance().registerAction("exportShortcutsAction", exportAction);
     }
 }
 


### PR DESCRIPTION
Fixing errors like:
```java
java.lang.Throwable: ID 'resetShortcutsAction' is already taken by action 'Reset Shortcuts Stats (Reset shortcuts stats)' (class com.github.marbor.shortcutsstats.actions.ResetAction) null. Action 'Reset Shortcuts Stats (Reset shortcuts stats)' (class com.github.marbor.shortcutsstats.actions.ResetAction) cannot use the same ID
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:376)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.reportActionIdCollision(ActionManagerImpl.kt:2053)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.registerAction(ActionManagerImpl.kt:2136)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.registerAction$default(ActionManagerImpl.kt:2122)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.registerAction(ActionManagerImpl.kt:974)
	at com.github.marbor.shortcutsstats.StatsToolWindow.createUIComponents(StatsToolWindow.java:103)
	at com.github.marbor.shortcutsstats.StatsToolWindow.$$$setupUI$$$(StatsToolWindow.java)
	at com.github.marbor.shortcutsstats.StatsToolWindow.<init>(StatsToolWindow.java:26)
	at com.github.marbor.shortcutsstats.StatsToolWindowFactory.createToolWindowContent(StatsToolWindowFactory.java:15)
	at com.intellij.openapi.wm.impl.ToolWindowImpl.createContentIfNeeded(ToolWindowImpl.kt:667)
	at com.intellij.openapi.wm.impl.ToolWindowImpl.scheduleContentInitializationIfNeeded$intellij_platform_ide_impl(ToolWindowImpl.kt:646)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.doShowWindow(ToolWindowManagerImpl.kt:1036)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.showToolWindowImpl(ToolWindowManagerImpl.kt:970)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.activateToolWindow$intellij_platform_ide_impl(ToolWindowManagerImpl.kt:670)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.activateToolWindow$intellij_platform_ide_impl$default(ToolWindowManagerImpl.kt:639)
	at com.intellij.openapi.wm.impl.ToolWindowManagerImpl.activated$intellij_platform_ide_impl(ToolWindowManagerImpl.kt:2301)
	at com.intellij.openapi.wm.impl.SquareAnActionButton.setSelected(SquareStripeButton.kt:333)
	at com.intellij.openapi.actionSystem.ToggleAction.actionPerformed(ToggleAction.java:60)
	at com.intellij.openapi.actionSystem.impl.ActionButton.actionPerformed(ActionButton.java:221)
	at com.intellij.openapi.actionSystem.impl.ActionButton.lambda$performAction$2(ActionButton.java:200)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.performWithActionCallbacks(ActionManagerImpl.kt:1173)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.performDumbAwareWithCallbacks(ActionUtil.kt:362)
	at com.intellij.openapi.actionSystem.impl.ActionButton.performAction(ActionButton.java:200)
	at com.intellij.openapi.actionSystem.impl.ActionButton.processMouseEvent(ActionButton.java:515)
	at java.desktop/java.awt.Component.processEvent(Component.java:6427)
	at java.desktop/java.awt.Container.processEvent(Container.java:2266)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5032)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4860)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4963)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4577)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4518)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2810)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4860)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:783)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:728)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:755)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:753)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:752)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:696)
	at com.intellij.ide.IdeEventQueue.dispatchMouseEvent(IdeEventQueue.kt:635)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$14(IdeEventQueue.kt:581)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:581)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:73)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:357)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:356)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:843)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:356)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke$lambda$0(IdeEventQueue.kt:1035)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:910)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:1036)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:114)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1036)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$10(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:397)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```